### PR TITLE
Support for multiple rigid-body selections

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ repository = "https://github.com/dennisbrookner/matchmaps"
 
 # same as console_scripts entry point
 [project.scripts]
-matchmaps = "matchmaps._compute_nonisomorphous_diff:main"
+matchmaps = "matchmaps._compute_realspace_diff:main"
 
 # Entry points
 # https://peps.python.org/pep-0621/#entry-points

--- a/src/matchmaps/_compute_realspace_diff.py
+++ b/src/matchmaps/_compute_realspace_diff.py
@@ -320,6 +320,7 @@ def parse_arguments():
         "-r",
         required=False,
         default=None,
+        nargs="*",
         help=(
             "Specification of multiple rigid-body groups for refinement. By default, everything is refined as one rigid-body group. "
         ),

--- a/src/matchmaps/_compute_realspace_diff.py
+++ b/src/matchmaps/_compute_realspace_diff.py
@@ -75,9 +75,8 @@ def compute_realspace_difference_map(
     verbose : bool, optional
         If True, print outputs of scaleit and phenix.refine, by default False
     rbr_selections : list of strings, optional
-        # Custom selection to provide to refinement.refine.sites.rigid_body=
-        # If omitted, then refinement.refine.sites.rigid_body=all
-        # Custom selection is only necessary if special-position atoms need to be excluded from refinement
+        Custom selections to provide to refinement.refine.sites.rigid_body=
+        If omitted, then refinement.refine.sites.rigid_body=all, and the entire structure is refined as a single rigid body. 
     eff : str, optional
         Name of a file containing a template .eff parameter file for phenix.refine.
         If omitted, the sensible built-in .eff template is used. If you need to change something,
@@ -207,12 +206,12 @@ def parse_arguments():
     """Parse commandline arguments."""
     parser = argparse.ArgumentParser(
         description=(
-            "Compute a difference map using non-isomorphous inputs. "
+            "Compute a real-space difference map. "
             "You will need two MTZ files, which will be referred to throughout as 'on' and 'off', "
             "though they could also be light/dark, bound/apo, mutant/WT, hot/cold, etc. "
             "Each mtz will need to contain structure factor amplitudes and uncertainties; you will not need any phases. "
             "You will, however, need an input model (assumed to correspond with the 'off' state) which will be used to determine phases. "
-            "Please note that both ccp4 and phenix must be installed and active in your environment for this function to work. "
+            "Please note that both ccp4 and phenix must be installed and active in your environment for this function to run. "
         )
     )
 
@@ -304,7 +303,7 @@ def parse_arguments():
         default=None,
         help=(
             "Highest-resolution (in Angstroms) reflections to include in Fourier transform for FloatGrid creation. "
-            "By default, cutoff is the resolution of the lower-resolution input MTZ. "
+            "By default, cutoff is the resolution limit of the lower-resolution input MTZ. "
         ),
     )
 

--- a/src/matchmaps/_compute_realspace_diff.py
+++ b/src/matchmaps/_compute_realspace_diff.py
@@ -76,7 +76,7 @@ def compute_realspace_difference_map(
         If True, print outputs of scaleit and phenix.refine, by default False
     rbr_selections : list of strings, optional
         Custom selections to provide to refinement.refine.sites.rigid_body=
-        If omitted, then refinement.refine.sites.rigid_body=all, and the entire structure is refined as a single rigid body. 
+        If omitted, then refinement.refine.sites.rigid_body=all, and the entire structure is refined as a single rigid body.
     eff : str, optional
         Name of a file containing a template .eff parameter file for phenix.refine.
         If omitted, the sensible built-in .eff template is used. If you need to change something,

--- a/src/matchmaps/_compute_realspace_diff.py
+++ b/src/matchmaps/_compute_realspace_diff.py
@@ -17,6 +17,7 @@ from matchmaps._utils import (
     rigid_body_refinement_wrapper,
     _realspace_align_and_subtract,
     _rbr_selection_parser,
+    _renumber_waters,
 )
 
 
@@ -109,7 +110,9 @@ def compute_realspace_difference_map(
     )
 
     pdboff = _handle_special_positions(pdboff, input_dir, output_dir)
-
+    
+    pdboff = _renumber_waters(pdboff, output_dir)
+    
     mtzon = mtzon_scaled
 
     print(f"{time.strftime('%H:%M:%S')}: Running phenix.refine for the 'on' data...")
@@ -184,8 +187,8 @@ def compute_realspace_difference_map(
             off_name_rbr = off_name + '_rbrgroup' + str(n)
             
             _realspace_align_and_subtract(
-                fg_off=fg_off,
-                fg_on=fg_on,
+                fg_off=fg_off.clone(),
+                fg_on=fg_on.clone(),
                 pdboff=pdboff,
                 pdbon=pdbon,
                 output_dir=output_dir,   
@@ -194,8 +197,7 @@ def compute_realspace_difference_map(
                 on_as_stationary=on_as_stationary,
                 selection=selection,      
             )
-
-
+            
     print(f"{time.strftime('%H:%M:%S')}: Done!")
 
     return

--- a/src/matchmaps/_utils.py
+++ b/src/matchmaps/_utils.py
@@ -449,11 +449,11 @@ def _realspace_align_and_subtract(
     masker.rprobe = 2  # this should do it, idk, no need to make this a user parameter
 
     # if selection is None:
-    if True:
+    if selection is None:
         pdb_for_mask = pdb_fixed[0]
     else:
         pdb_for_mask = _extract_pdb_selection(pdb_fixed[0], selection)
-        
+       
     masker.put_mask_on_float_grid(fg_mask_only, pdb_for_mask)
     masked_difference_array = np.logical_not(fg_mask_only.array) * difference_array
 
@@ -560,4 +560,8 @@ def _extract_pdb_selection(pdb, selection):
     # return a gemmi.Model containing only the selected things
     # selection can be either a string or a list of strings
     
-    return
+    sel = gemmi.Selection(selection)
+        
+    pdb_selection = sel.copy_model_selection(pdb)
+
+    return pdb_selection

--- a/src/matchmaps/_utils.py
+++ b/src/matchmaps/_utils.py
@@ -319,17 +319,19 @@ def _handle_special_positions(pdboff, input_dir, output_dir):
                                 "   Input model contains water at special position. Removing water so as to not break rigid-body refinement."
                             )
                             print(
-                                "   If it is important that you keep this water and just omit it from your refinement selection, use the --rbr-selections flag"
+                                # "   If it is important that you keep this water and just omit it from your refinement selection, you many the --rbr-selections flag"
                             )
                             residue.remove_atom(
                                 name=atom.name, altloc=atom.altloc, el=atom.element
                             )
 
                         else:
-                            raise ValueError(
+                            raise NotImplementedError(
                                 """
-Input model contains a non-water atom on a special position.
-Please use the --rbr-selections flag to supply an input suitable for rigid-body refinement by phenix.
+Input model contains a non-water atom on a special position, which is not allowed in rigid-body refinement.
+You may attempt to exclude this atom via a custom atom selection to the `--rbr-selections` argument, but this feature is not currently tested.
+
+Alternatively, you can remove this atom from your structure altogether and try again.
 """
                             )
 

--- a/src/matchmaps/_utils.py
+++ b/src/matchmaps/_utils.py
@@ -8,10 +8,82 @@ are exported to python for use in prototyping and testing
 import glob
 import shutil
 import subprocess
+import time
+import re
+from functools import partial
 
 import gemmi
 import numpy as np
 import reciprocalspaceship as rs
+
+
+def _rbr_selection_parser(rbr_selections):
+    # end early and return nones if this feature isn't being used
+    if rbr_selections is None:
+        return None, None
+
+    # validate input is a list of strings
+    if not isinstance(rbr_selections, list):
+        raise ValueError(
+            f"rbr_selections must be a list of str, not {type(rbr_selections).__name__}"
+        )
+    if not all([isinstance(sel, str) for sel in rbr_selections]):
+        raise ValueError(
+            f"rbr_selections must be a list of str, not list of {[type(sel).__name__ for sel in rbr_selections]}"
+        )
+
+    # get rid of spaces, which have no semantic meaning to my parser
+    rbr_selections = [g.replace(" ", "") for g in rbr_selections]
+    print(rbr_selections)
+    phenix_selections = []
+    gemmi_selections = []
+
+    for group in rbr_selections:
+        # check if there are multiple, separate selections
+        # that make up this rigid-body selection
+        if len(group.split(",")) > 1:
+            subgroups = group.split(",")
+            phegem = [_subparser(sub) for sub in subgroups]
+
+            phenixtemp = [pg[0] for pg in phegem]
+
+            phe = " or ".join([f"({p})" for p in phenixtemp])
+
+            gem = phegem[0][1]
+
+            phenix_selections.append(phe)
+            gemmi_selections.append(gem)
+
+        # just one selection in each
+        else:
+            phe, gem = _subparser(group)
+            print(phe)
+            phenix_selections.append(phe)
+            gemmi_selections.append(gem)
+
+    return phenix_selections, gemmi_selections
+
+
+def _subparser(selection):
+    if selection.isalpha():  # just a chain name
+        phe = "chain " + selection
+        gem = selection
+
+    else:
+        chain = "".join(re.findall("[a-zA-Z]", selection))
+        residues = selection.removeprefix(chain)
+
+        if "-" in residues:
+            start, end = [int(r) for r in residues.split("-")]
+
+            phe = f"chain {chain} and resseq {start}:{end}"
+            gem = f"{chain}/{start}-{end}"
+
+        else:
+            phe = f"chain {chain} and resid {residues}"
+            gem = f"{chain}/{residues}"
+
+    return phe, gem
 
 
 def make_floatgrid_from_mtz(mtz, spacing, F, Phi, spacegroup="P1", dmin=None):
@@ -88,7 +160,7 @@ def rigid_body_refinement_wrapper(
     ligands=None,
     eff=None,
     verbose=False,
-    selection=None,
+    rbr_selections=None,
 ):
     # confirm that phenix is active in the command-line environment
     if shutil.which("phenix.refine") is None:
@@ -138,7 +210,7 @@ refinement {
   refine {
     strategy = *rigid_body
     sites {
-      rigid_body = all
+      rigid_body_sites
     }
   }
   main {
@@ -185,8 +257,8 @@ refinement {
     else:
         params["columns"] = off_labels
 
-    if selection is not None:
-        params["all"] = selection  # overwrite atom selection
+    # if selection is not None:
+    #     params["all"] = selection  # overwrite atom selection
 
     for key, value in params.items():
         eff_contents = eff_contents.replace(key, value)
@@ -197,6 +269,12 @@ refinement {
         eff_contents = eff_contents.replace("ligands", ligand_string)
     else:
         eff_contents = eff_contents.replace("ligands", "")
+
+    if rbr_selections is not None:
+        selection_string = "\n".join([f"rigid_body = '{sel}'" for sel in rbr_selections])
+        eff_contents = eff_contents.replace("rigid_body_sites", selection_string)
+    else:
+        eff_contents = eff_contents.replace("rigid_body_sites", "rigid_body = all")
 
     # write out customized .eff file for use by phenix
     with open(eff, "w") as file:
@@ -268,7 +346,122 @@ Please use the --selection flag to supply an input suitable for rigid-body refin
     return pdboff_nospecialpositions
 
 
-def align_grids_from_model_transform(grid1, grid2, structure1, structure2):
+def _realspace_align_and_subtract(
+    output_dir,
+    fg_off,
+    fg_on,
+    pdboff,
+    pdbon,
+    on_name,
+    off_name,
+    on_as_stationary,
+    selection,
+):
+    """
+    Take in two floatgrids and two pdbs. Apply the alignment transformation and subtract.
+
+    If there were multiple selections used for rigid-body refinement, this method should be called separately for each selection.
+
+    Parameters
+    ----------
+    output_dir : _type_
+        _description_
+    fg_off : _type_
+        _description_
+    fg_on : _type_
+        _description_
+    pdboff : _type_
+        _description_
+    pdbon : _type_
+        _description_
+    on_name : _type_
+        _description_
+    off_name : _type_
+        _description_
+    on_as_stationary : _type_
+        _description_
+    selection : str or list of str
+        If not None, should be a valid gemmi selection string or a list of valid gemmi selection strings
+    """
+
+    print(f"{time.strftime('%H:%M:%S')}: Using models to rigid-body align maps...")
+    
+    if on_as_stationary:
+        fg_fixed = fg_on
+        pdb_fixed = pdbon
+    else:
+        fg_fixed = fg_off
+        pdb_fixed = pdboff
+    
+    fg_off = align_grids_from_model_transform(
+        fg_fixed, fg_off, pdb_fixed, pdboff, selection
+    )
+    fg_on = align_grids_from_model_transform(
+        fg_fixed, fg_on, pdb_fixed, pdbon, selection
+    )
+
+    print(f"{fg_off.array.mean()=}, {fg_on.array.mean()=}")
+
+    # do this again, because transformation + carving can mess up scales:
+    fg_on.normalize()
+    fg_off.normalize()
+
+    print(f"{fg_off.array.mean()=}, {fg_on.array.mean()=}")
+
+    print(f"{time.strftime('%H:%M:%S')}: Writing files...")
+
+    difference_array = fg_on.array - fg_off.array
+
+    # all that's left is to mask out voxels that aren't near the model!
+    # we can do this in gemmi
+    fg_mask_only = fg_fixed.clone()
+    masker = gemmi.SolventMasker(gemmi.AtomicRadiiSet.Cctbx)
+    masker.rprobe = 2  # this should do it, idk, no need to make this a user parameter
+
+    masker.put_mask_on_float_grid(fg_mask_only, pdb_fixed[0])
+    masked_difference_array = np.logical_not(fg_mask_only.array) * difference_array
+
+    # and finally, write stuff out
+
+    # coot refuses to render periodic boundaries for P1 maps with alpha=beta=gamma=90, sooooo
+    if all(
+        [
+            angle == 90
+            for angle in (
+                fg_fixed.unit_cell.alpha,
+                fg_fixed.unit_cell.beta,
+                fg_fixed.unit_cell.gamma,
+            )
+        ]
+    ):
+        fg_fixed.unit_cell = gemmi.UnitCell(
+            fg_fixed.unit_cell.a,
+            fg_fixed.unit_cell.b,
+            fg_fixed.unit_cell.c,
+            90.006,
+            fg_fixed.unit_cell.beta,
+            fg_fixed.unit_cell.gamma,
+        )
+        print("did silly angle thing")
+
+    # use partial function to guarantee I'm always using the same and correct cell
+    write_maps = partial(
+        rs.io.write_ccp4_map, cell=fg_fixed.unit_cell, spacegroup=fg_fixed.spacegroup
+    )
+
+    write_maps(fg_on.array, f"{output_dir}/{on_name}.map")
+
+    write_maps(fg_off.array, f"{output_dir}/{off_name}.map")
+
+    write_maps(masked_difference_array, f"{output_dir}/{on_name}_minus_{off_name}.map")
+    write_maps(
+        difference_array, f"{output_dir}/{on_name}_minus_{off_name}_unmasked.map"
+    )
+
+    return
+
+
+def align_grids_from_model_transform(grid1, grid2, structure1, structure2, selection):
     """
     This function is basically just a wrapper around `gemmi.interpolate_grid_of_aligned_model2`, which is an amazing thing that exists!!.
 
@@ -282,14 +475,30 @@ def align_grids_from_model_transform(grid1, grid2, structure1, structure2):
         _description_
     structure2 : gemmi.Structure
         _description_
+    selection : str
+        a string sufficient to describe the rbr selection to gemmi
+        If the rbr selection contained multiple chains / spans, can just be the first chain / span
 
     Returns
     -------
     grid2_out : gemmi.FloatGrid
         Aligned, interpolated, and trimmed grid
     """
-    span1 = structure1[0]["A"].get_polymer()
-    span2 = structure2[0]["A"].get_polymer()
+    
+    if selection is None:
+        span1 = structure1[0][0].get_polymer()
+        span2 = structure2[0][0].get_polymer()
+        
+        dest_model = structure1[0]
+    
+    else:
+        sel = gemmi.selection(selection)
+        
+        span1 = sel.copy_structure_selection(structure1)[0][0].get_polymer()
+        span2 = sel.copy_structure_selection(structure2)[0][0].get_polymer()
+        
+        dest_model = sel.copy_structure_selection(structure1)[0]
+    
     sup = gemmi.calculate_superposition(
         span1, span2, span1.check_polymer_type(), gemmi.SupSelect.CaP
     )


### PR DESCRIPTION
This update supports multiple rigid-body selections, specified as e.g. `-r A B`. These will be rigid-body refined separately. The maps will be aligned separately for each rigid-body selection, resulting in a separate difference map for each.

Currently, only selections of an entire, single chain are well-tested.