### PR TITLE
Bug fixes to `matchmaps.mr`

### DIFF
--- a/src/matchmaps/_compute_mr_diff.py
+++ b/src/matchmaps/_compute_mr_diff.py
@@ -145,7 +145,7 @@ def compute_mr_difference_map(
         verbose=verbose,
         rbr_selections=rbr_phenix,
         off_labels=f"{Fon},{SigFon}",  # workaround for compatibility
-        mr_naming=True
+        mr_naming=True,
     )
 
     print(f"{time.strftime('%H:%M:%S')}: Running phenix.refine for the 'off' data...")

--- a/src/matchmaps/_compute_mr_diff.py
+++ b/src/matchmaps/_compute_mr_diff.py
@@ -126,8 +126,8 @@ def compute_mr_difference_map(
     # TO-DO: fix ligand occupancies in pdb_mr_to_on
     edited_mr_pdb = _restore_ligand_occupancy(
         pdb_to_be_restored=phaser_nickname + ".1.pdb",
-        # original_pdb=pdboff,
-        ligands=ligands,
+        original_pdb=pdboff,
+        # ligands=ligands,
         output_dir=output_dir,
     )
 
@@ -145,6 +145,7 @@ def compute_mr_difference_map(
         verbose=verbose,
         rbr_selections=rbr_phenix,
         off_labels=f"{Fon},{SigFon}",  # workaround for compatibility
+        mr_naming=True
     )
 
     print(f"{time.strftime('%H:%M:%S')}: Running phenix.refine for the 'off' data...")

--- a/src/matchmaps/_utils.py
+++ b/src/matchmaps/_utils.py
@@ -161,6 +161,7 @@ def rigid_body_refinement_wrapper(
     eff=None,
     verbose=False,
     rbr_selections=None,
+    mr_naming=False,
 ):
     # confirm that phenix is active in the command-line environment
     if shutil.which("phenix.refine") is None:
@@ -223,7 +224,7 @@ refinement {
         with open(input_dir + eff) as file:
             eff_contents = file.read()
 
-    if off_labels is None:
+    if (off_labels is None) or (mr_naming):
         nickname = f"{mtzon.removesuffix('.mtz')}_rbr_to_{pdboff.removesuffix('.pdb')}"
     else:
         nickname = f"{mtzon.removesuffix('.mtz')}_rbr_to_self"
@@ -535,7 +536,6 @@ def _restore_ligand_occupancy(
     n = 0
     for i in range(len(pdb)):
         if ("HETATM" in pdb[i]) and (not "REMARK" in pdb[i]):
-            print(i, n)
             pdb[i] = pdb[i][:56] + original_occs[n] + pdb[i][60:]
             n += 1
 


### PR DESCRIPTION
This PR fixes a true bug and a weird behavior in `matchmaps.mr`

### The bug
The `_restore_ligand_occupancy()` call signature had been updated, but the call to this method inside of `compute_mr_difference_map()` had not, leading to an error thrown when using `matchmaps.mr`. This is now fixed as of this PR, and shortly as of matchmaps 0.3.1.

### The weird behavior
In the vanilla `matchmaps` function, `phenix.refine` outputs are titled either `XXX_rbr_to_YYY` or `YYY_rbr_to_self`, as appropriate. When putting together `matchmaps.mr`, a hacky reverse compatibility led to all refinement outputs having the `_rbr_to_self` format, even when this was not accurate. This behavior is now fixed via an extra argument to `rigid_body_refinement_wrapper()` which is only used in the MR case.